### PR TITLE
Fix the URL for AngelList

### DIFF
--- a/src/_data/resources.yml
+++ b/src/_data/resources.yml
@@ -13,7 +13,7 @@ AI Jobs:
 AngelList:
   category: Job Boards
   tags: Startups, Work
-  url: https://ai-jobs.net/
+  url: https://angel.co/
   description: "AngelList is a main resource when it comes to startup jobs, networking and fundraising worldwide."
 
 Towards Data Science:


### PR DESCRIPTION
The URL for AngelList needs to be updated, as it contains a duplicate and incorrect link to AI Jobs